### PR TITLE
Pin fastapi<0.137.0 to fix _IncludedRouter AttributeError on startup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 bs4
 dateparser
 python-dotenv
-fastapi
+fastapi<0.137.0
 uvicorn
 tzdata
 lxml


### PR DESCRIPTION
fastapi 0.137.0 introduces a change that causes an `_IncludedRouter`
AttributeError on startup. Pinning to <0.137.0 in requirements.txt
avoids the crash until compatibility is restored.